### PR TITLE
Add Docker-based deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+**/__pycache__
+**/*.pyc
+frontend/node_modules
+frontend/dist
+backend/.venv
+backend/data
+backend/.pytest_cache
+backend/.mypy_cache

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 *.db
 .env
 .env.*
+!.env.example
+!backend/.env.example
+!backend/.env.docker.example
 venv/
 .venv/
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1.6
+
+############################################################
+# Frontend build stage
+############################################################
+FROM node:20-alpine AS frontend-builder
+WORKDIR /usr/src/app/frontend
+
+# Install dependencies first to leverage Docker layer caching
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --legacy-peer-deps
+
+# Copy the rest of the frontend source and build the production bundle
+COPY frontend/ ./
+RUN npm run build
+
+############################################################
+# Backend runtime stage
+############################################################
+FROM python:3.11-slim AS backend
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    POETRY_VIRTUALENVS_CREATE=false \
+    POETRY_NO_INTERACTION=1
+
+WORKDIR /app
+
+# Install system dependencies required for Python packages
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry and project dependencies
+RUN pip install poetry==1.7.1
+COPY backend/pyproject.toml backend/poetry.lock ./
+RUN poetry install --without dev --no-root
+
+# Copy the backend application code
+COPY backend/ ./
+
+# Ensure the SQLite data directory exists by default
+RUN mkdir -p /app/data
+
+# Copy the built frontend from the previous stage and configure FastAPI to serve it
+COPY --from=frontend-builder /usr/src/app/frontend/dist /app/frontend_dist
+ENV FRONTEND_BUILD_DIR=/app/frontend_dist \
+    PYTHONPATH=/app
+
+EXPOSE 8000
+
+# Run database migrations automatically before starting the server
+CMD ["/bin/sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project provides a full-stack foundation for a US university counseling assistant that helps applicants evaluate and improve their applications using GPT-5 through the OpenAI API.
 
+The repository now ships with a production-ready Docker image that bundles the API and the compiled React single-page application so that the platform can be deployed to a standard web server with a single command.
+
 ## Project Structure
 
 ```
@@ -14,19 +16,16 @@ This project provides a full-stack foundation for a US university counseling ass
 
 ## Backend Setup
 
-1. Install dependencies using [Poetry](https://python-poetry.org/):
+1. Copy `.env.example` to `.env` and fill in the required secrets:
    ```bash
    cd backend
-   poetry install
+   cp .env.example .env
+   # Edit .env to set OPENAI_API_KEY and JWT_SECRET_KEY
    ```
 
-2. Create a `.env` file inside `backend/` with the following variables:
-   ```env
-   OPENAI_API_KEY=your-openai-key
-   DATABASE_URL=sqlite+aiosqlite:///./data/app.db
-   JWT_SECRET_KEY=replace-with-strong-secret
-   CORS_ORIGINS=http://localhost:5173
-   FRONTEND_BUILD_DIR=../frontend/dist
+2. Install dependencies using [Poetry](https://python-poetry.org/):
+   ```bash
+   poetry install
    ```
 
 3. Apply database migrations:
@@ -67,6 +66,28 @@ The React dashboard includes dedicated routes for the applicant overview, evalua
    ```
 
    The generated files live in `frontend/dist/`. The FastAPI app automatically serves this directory when `FRONTEND_BUILD_DIR` points to it (the default), so running `uvicorn` will host the API and the compiled web client together.
+
+## Containerized Deployment
+
+To deploy the full stack behind a single web service, use the provided Docker setup. The multi-stage image builds the React dashboard, installs the FastAPI backend, applies database migrations, and serves everything through Uvicorn.
+
+1. Copy the Docker environment template and populate the required values:
+   ```bash
+   cp backend/.env.docker.example backend/.env.docker
+   # Edit backend/.env.docker to set OPENAI_API_KEY and JWT_SECRET_KEY
+   ```
+
+2. Start the stack:
+   ```bash
+   docker compose up --build
+   ```
+
+   The service exposes port `8000` by default. Visit `http://localhost:8000/app` to access the frontend and `http://localhost:8000/docs` for the interactive API documentation. Static assets and the API share the same container, making deployment on platforms such as DigitalOcean, Fly.io, Render, or any Docker-compatible host straightforward.
+
+3. To run database migrations manually (for example during upgrades), execute:
+   ```bash
+   docker compose run --rm web alembic upgrade head
+   ```
 
 ## Documentation
 

--- a/backend/.env.docker.example
+++ b/backend/.env.docker.example
@@ -1,0 +1,10 @@
+APP_NAME=US College Counseling API
+DEBUG=false
+DATABASE_URL=sqlite+aiosqlite:///./data/app.db
+OPENAI_API_KEY=replace-with-your-openai-api-key
+OPENAI_MODEL=gpt-5
+JWT_SECRET_KEY=replace-with-a-strong-secret
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=1440
+CORS_ORIGINS=http://localhost:5173,http://localhost:8000
+FRONTEND_BUILD_DIR=/app/frontend_dist

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to `.env` and adjust the values for your environment.
+APP_NAME=US College Counseling API
+DEBUG=false
+DATABASE_URL=sqlite+aiosqlite:///./data/app.db
+OPENAI_API_KEY=replace-with-your-openai-api-key
+OPENAI_MODEL=gpt-5
+JWT_SECRET_KEY=replace-with-a-strong-secret
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=1440
+CORS_ORIGINS=http://localhost:5173,http://localhost:8000
+FRONTEND_BUILD_DIR=../frontend/dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: us-college-counseling:web
+    ports:
+      - "8000:8000"
+    env_file:
+      - backend/.env.docker
+    volumes:
+      - ./backend/data:/app/data
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the Vite frontend, installs the FastAPI backend, and runs migrations before serving the app
- provide docker-compose configuration, environment templates, and ignore rules to streamline containerized deployments
- document the new deployment flow and environment setup in the README

## Testing
- `poetry run pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68de1ee86b08832ab94821f23e32610f