### PR TITLE
Parse essay feedback JSON and document Google Cloud deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,36 @@ To deploy the full stack behind a single web service, use the provided Docker se
    docker compose run --rm web alembic upgrade head
    ```
 
+## Deploying to Google Cloud Compute Engine
+
+When you are ready to host the platform on Google Cloud, the repository ships with a helper script that builds the Docker image, publishes it to Artifact Registry, and provisions a Compute Engine instance that runs the container with your configuration.
+
+1. Prerequisites:
+   - Install the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) and authenticate with `gcloud auth login`.
+   - Enable the Artifact Registry and Compute Engine APIs in your project: `gcloud services enable artifactregistry.googleapis.com compute.googleapis.com`.
+   - Ensure Docker is installed locally and that you have permission to push images.
+   - Create `backend/.env.docker` (or another env file) with production-ready secrets.
+
+2. Run the deployment script from the repository root, providing the required environment variables:
+   ```bash
+   export PROJECT_ID="your-gcp-project"
+   export ENV_FILE="backend/.env.docker"  # or a custom path with your secrets
+   ./scripts/deploy_to_gce.sh
+   ```
+
+   Optional variables include `REGION`, `ZONE`, `MACHINE_TYPE`, `IMAGE_TAG`, and `INSTANCE_NAME`. The script will:
+   - Create an Artifact Registry repository if it does not exist.
+   - Build and push the Docker image to `${REGION}-docker.pkg.dev/${PROJECT_ID}`.
+   - Provision (or replace) a Container-Optimized OS VM and launch the container with your environment file.
+   - Open firewall rules for HTTP traffic on ports 80 and 8000.
+
+3. After the VM boots, retrieve its external IP with:
+   ```bash
+   gcloud compute instances describe "$INSTANCE_NAME" --zone "$ZONE" --format='get(networkInterfaces[0].accessConfigs[0].natIP)'
+   ```
+
+   Visit `http://<external-ip>:8000/app` to reach the frontend and `http://<external-ip>:8000/docs` for the API documentation.
+
 ## Documentation
 
 Additional documentation lives under `docs/`:

--- a/backend/app/services/essays.py
+++ b/backend/app/services/essays.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,13 +27,57 @@ class EssayService:
             },
         ]
         content = await self.openai_client.complete(messages)
+        summary = self._summarize_feedback(content)
         evaluation = await evaluation_repository.create(
             db,
             {
                 "applicant_id": essay.applicant_id,
                 "essay_id": essay.id,
                 "model_name": self.openai_client.model,
-                "summary": content,
+                "summary": summary,
             },
         )
         return evaluation
+
+    def _summarize_feedback(self, content: str) -> str:
+        try:
+            payload = json.loads(content)
+        except json.JSONDecodeError:
+            return content.strip()
+
+        sections: list[str] = []
+        mapping = {
+            "Strengths": payload.get("strengths"),
+            "Areas for improvement": payload.get("areas_for_improvement"),
+            "Revision plan": payload.get("revision_plan"),
+        }
+
+        for title, value in mapping.items():
+            formatted = self._format_section(title, value)
+            if formatted:
+                sections.append(formatted)
+
+        if sections:
+            return "\n\n".join(sections)
+        return content.strip()
+
+    def _format_section(self, title: str, value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            text = value.strip()
+            return f"{title}: {text}" if text else None
+        if isinstance(value, list):
+            items = [str(item).strip() for item in value if str(item).strip()]
+            if not items:
+                return None
+            bullet_list = "\n".join(f"- {item}" for item in items)
+            return f"{title}:\n{bullet_list}"
+        if isinstance(value, dict):
+            items = [f"{key}: {str(val).strip()}" for key, val in value.items() if str(val).strip()]
+            if not items:
+                return None
+            bullet_list = "\n".join(f"- {item}" for item in items)
+            return f"{title}:\n{bullet_list}"
+        text = str(value).strip()
+        return f"{title}: {text}" if text else None

--- a/scripts/deploy_to_gce.sh
+++ b/scripts/deploy_to_gce.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy the US College Admission Counseling stack to a Google Compute Engine
+# instance backed by the Container-Optimized OS image. The script assumes you
+# have already authenticated with `gcloud auth login` and selected a project.
+
+PROJECT_ID="${PROJECT_ID:-}"
+REGION="${REGION:-us-central1}"
+ZONE="${ZONE:-us-central1-a}"
+ARTIFACT_REPO_NAME="${ARTIFACT_REPO_NAME:-us-college-counseling}"
+IMAGE_NAME="${IMAGE_NAME:-us-college-counseling}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+INSTANCE_NAME="${INSTANCE_NAME:-us-college-counseling}"
+MACHINE_TYPE="${MACHINE_TYPE:-e2-standard-2}"
+ENV_FILE="${ENV_FILE:-backend/.env.docker}"
+
+if [[ -z "${PROJECT_ID}" ]]; then
+  echo "PROJECT_ID is required. Set it in the environment or export PROJECT_ID before running." >&2
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Environment file '${ENV_FILE}' not found. Provide a Docker-ready env file via ENV_FILE." >&2
+  exit 1
+fi
+
+set -x
+
+gcloud config set project "${PROJECT_ID}"
+
+REPO_PATH="${REGION}-docker.pkg.dev/${PROJECT_ID}/${ARTIFACT_REPO_NAME}"
+
+if ! gcloud artifacts repositories describe "${ARTIFACT_REPO_NAME}" \
+  --location="${REGION}" >/dev/null 2>&1; then
+  gcloud artifacts repositories create "${ARTIFACT_REPO_NAME}" \
+    --repository-format=docker \
+    --location="${REGION}" \
+    --description="Container images for the US college counseling platform"
+fi
+
+gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+docker build -t "${REPO_PATH}/${IMAGE_NAME}:${IMAGE_TAG}" .
+
+docker push "${REPO_PATH}/${IMAGE_NAME}:${IMAGE_TAG}"
+
+if ! gcloud compute firewall-rules describe "${INSTANCE_NAME}-allow-http" >/dev/null 2>&1; then
+  gcloud compute firewall-rules create "${INSTANCE_NAME}-allow-http" \
+    --allow=tcp:80,tcp:8000 \
+    --target-tags="${INSTANCE_NAME}" \
+    --description="Allow HTTP traffic to the counseling app"
+fi
+
+if gcloud compute instances describe "${INSTANCE_NAME}" --zone="${ZONE}" >/dev/null 2>&1; then
+  gcloud compute instances delete "${INSTANCE_NAME}" --zone="${ZONE}" --quiet
+fi
+
+gcloud compute instances create-with-container "${INSTANCE_NAME}" \
+  --zone="${ZONE}" \
+  --machine-type="${MACHINE_TYPE}" \
+  --tags="${INSTANCE_NAME}" \
+  --container-image="${REPO_PATH}/${IMAGE_NAME}:${IMAGE_TAG}" \
+  --container-env-file="${ENV_FILE}" \
+  --boot-disk-size=30GB \
+  --boot-disk-type=pd-balanced \
+  --scopes=https://www.googleapis.com/auth/cloud-platform
+
+set +x
+
+echo "Deployment complete. Once the VM finishes booting, access the app via the instance's external IP on port 8000."


### PR DESCRIPTION
## Summary
- parse and format essay critique responses before saving evaluations so the dashboard shows readable feedback
- add a helper script for deploying to Google Compute Engine and document the workflow in the README

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_b_68ec760542e8832aa35827f9ab65b779